### PR TITLE
Relative image reference instead of full http link to avoid mixed con…

### DIFF
--- a/about.html
+++ b/about.html
@@ -13,7 +13,7 @@
   <body>
     <div id="banner">
       <h1 id="title">
-              <a href="http://www.w3.org/"><img alt="W3C" width="110" height="61" id="logo" src="http://validator.w3.org/images/w3c.png" /></a>
+              <a href="http://www.w3.org/"><img alt="W3C" width="110" height="61" id="logo" src="/images/w3c.png" /></a>
 <a href="./"><span>Feed Validation Service</span></a>
 </h1>
 			  <p id="tagline">Check the syntax of Atom or RSS feeds</p>

--- a/docs-xml/docs-index-header.html
+++ b/docs-xml/docs-index-header.html
@@ -17,7 +17,7 @@
   <body>
         <div id="banner">
           <h1 id="title">
-                  <a href="http://www.w3.org/"><img alt="W3C" width="110" height="61" id="logo" src="http://validator.w3.org/images/w3c.png" /></a>
+                  <a href="http://www.w3.org/"><img alt="W3C" width="110" height="61" id="logo" src="/images/w3c.png" /></a>
     <a href="../"><span>Feed Validation Service</span></a>
     </h1>
     			  <p id="tagline">Check the syntax of Atom or RSS feeds</p>

--- a/docs-xml/template.html
+++ b/docs-xml/template.html
@@ -14,7 +14,7 @@
   <body>
         <div id="banner">
           <h1 id="title">
-                  <a href="http://www.w3.org/"><img alt="W3C" width="110" height="61" id="logo" src="http://validator.w3.org/images/w3c.png" /></a>
+                  <a href="http://www.w3.org/"><img alt="W3C" width="110" height="61" id="logo" src="/images/w3c.png" /></a>
     <a href="../../"><span>Feed Validation Service</span></a>
     </h1>
     			  <p id="tagline">Check the syntax of Atom or RSS feeds</p>

--- a/docs/soap.html
+++ b/docs/soap.html
@@ -17,7 +17,7 @@
   <body>
         <div id="banner">
           <h1 id="title">
-                  <a href="http://www.w3.org/"><img alt="W3C" width="110" height="61" id="logo" src="http://validator.w3.org/images/w3c.png" /></a>
+                  <a href="http://www.w3.org/"><img alt="W3C" width="110" height="61" id="logo" src="/images/w3c.png" /></a>
     <a href="./"><span>Feed Validation Service</span></a>
     </h1>
     			  <p id="tagline">Check the syntax of Atom or RSS feeds</p>

--- a/whatsnew.html
+++ b/whatsnew.html
@@ -14,7 +14,7 @@
   <body>
         <div id="banner">
           <h1 id="title">
-                  <a href="http://www.w3.org/"><img alt="W3C" width="110" height="61" id="logo" src="http://validator.w3.org/images/w3c.png" /></a>
+                  <a href="http://www.w3.org/"><img alt="W3C" width="110" height="61" id="logo" src="/images/w3c.png" /></a>
     <a href="./"><span>Feed Validation Service</span></a>
     </h1>
     			  <p id="tagline">Check the syntax of Atom or RSS feeds</p>


### PR DESCRIPTION
…tent warnings

Several pages on the feedvalidator webpage show mixed content warnings, i.e. HTTP content in HTTPS pages.
As all these are files on the same host I changed them to relative references.