### PR TITLE
Fix format in docker example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,7 @@ provided.
 Python 2.3.x is required, for its Unicode support.
 
 To run with Docker:
+```bash
 docker build -t feedvalidator .
 docker run -p 8080:80 feedvalidator
+```


### PR DESCRIPTION
Right now shows both commands in one line