### PR TITLE
Fix broken page anchor link on docs/atom.html

### DIFF
--- a/docs/atom.html
+++ b/docs/atom.html
@@ -284,7 +284,7 @@ More info <a href="#person">here</a>.
 
 <tr>
 <td valign="top">content</td>
-<td valign="top">Contains or links to the complete content of the entry.  Content must be provided if there is no <code>alternate</code> link, and should be provided if there is no <code>summary</code>.  More info <a href="#content">here</a>.
+<td valign="top">Contains or links to the complete content of the entry.  Content must be provided if there is no <code>alternate</code> link, and should be provided if there is no <code>summary</code>.  More info <a href="#contentElement">here</a>.
 <pre>&lt;content&gt;complete story here&lt;/content&gt;</pre></td>
 </tr>
 


### PR DESCRIPTION
A fix so that one of the anchor links opens the Content section of the page correctly.