### PR TITLE
Add podcasting 2.0 namespace to unsupported namespaces

### DIFF
--- a/src/feedvalidator/base.py
+++ b/src/feedvalidator/base.py
@@ -88,7 +88,9 @@ unsupported_namespaces = {
   "http://schemas.google.com/g/2005": ("Google Data", "https://developers.google.com/gdata/docs/1.0/elements"),
   "http://www.rawvoice.com/rawvoiceRssModule/":	("RawVoice", "http://www.rawvoice.com/services/tools-and-resources/rawvoice-rss-2-0-module-xmlns-namespace-rss2/"),
   "https://schema.org/": ("Schema.org", "https://schema.org/"),
-  "http://schema.org/": ("Schema.org", "https://schema.org/")
+  "http://schema.org/": ("Schema.org", "https://schema.org/"),
+  "https://podcastindex.org/namespace/1.0": ("Podcasting 2.0", "https://podcastindex.org/"),
+  "https://github.com/Podcastindex-org/podcast-namespace/blob/main/docs/1.0.md": ("Podcasting 2.0", "https://github.com/Podcastindex-org/podcast-namespace/")
 }
 
 def near_miss(ns):


### PR DESCRIPTION
So it doesn't show a warning like #84 

Example feeds for testing:
https://kdeexpress.gitlab.io/feed
https://kdeexpress.gitlab.io/feed_mp3